### PR TITLE
Optimize first stage for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@
 
 ###  stage 1 ###
 FROM adoptopenjdk/maven-openjdk11 as BUILD
-  
-COPY src /usr/src/app/src
-COPY ./pom.xml /usr/src/app
+
 WORKDIR /usr/src/app
-RUN mvn package
+COPY ./pom.xml .
+RUN mvn -ntp install dependency:go-offline -DskipTests
+
+COPY src ./src
+RUN mvn -ntp package
 
 ### stage 2  ###
  


### PR DESCRIPTION
The technique in the PR makes development a bit faster for iterations that change only the code, but not the dependencies of the application, by caching all dependencies in a layer that is separate from the source code.

Since code changes happen more often than dependency changes, this tends to make things go a little faster. The added space cost of the additional layer is restricted to the first stage, so there is really no penalty.

Sample output of the last lines of the build, showing that it does not impact the results:

```
#13 41.42 [INFO] --- quarkus-maven-plugin:1.13.1.Final:build (default) @ mq-quarkus-app ---
#13 42.72 [INFO] [org.jboss.threads] JBoss Threads version 3.2.0.Final
#13 43.14 [WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
#13 43.19 [WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
#13 43.22 [WARNING] Error reading service account token from: [/var/run/secrets/kubernetes.io/serviceaccount/token]. Ignoring.
#13 43.61 [INFO] [io.quarkus.kubernetes.deployment.KubernetesDeployer] Selecting target 'openshift' since it has the highest priority among the implicitly enabled deployment targets
#13 44.61 [INFO] [io.quarkus.arc.processor.BeanProcessor] Found unrecommended usage of private members (use package-private instead) in application beans:
#13 44.62 	- @Inject field com.ibm.mqclient.service.MQService#jmsTemplate,
#13 44.62 	- @Inject field com.ibm.mqclient.service.MyJMSTemplate#appName,
#13 44.62 	- @Inject field com.ibm.mqclient.service.MyJMSTemplate#mqAppUser
#13 44.62 	- and 7 more - please enable debug logging to see the full list
#13 46.44 [INFO] Checking for existing resources in: /usr/src/app/src/main/kubernetes.
#13 48.46 [INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 7009ms
#13 48.48 [INFO] ------------------------------------------------------------------------
#13 48.48 [INFO] BUILD SUCCESS
#13 48.48 [INFO] ------------------------------------------------------------------------
#13 48.48 [INFO] Total time:  46.195 s
#13 48.48 [INFO] Finished at: 2021-04-16T18:42:34Z
#13 48.48 [INFO] ------------------------------------------------------------------------
#13 DONE 49.0s

#14 [stage-1 3/6] COPY --from=BUILD /usr/src/app/target/quarkus-app/lib/ /deployments/lib/
#14 sha256:723ed50e280ce68d2eb511d3cbad7cdfd8c39aed1717a02bbff6f177804b34e0
#14 DONE 0.2s

#15 [stage-1 4/6] COPY --from=BUILD /usr/src/app/target/quarkus-app/*.jar /deployments/
#15 sha256:7b5bc5d521012675a965d1b83a75416d17c4f14d3d7f806dcc66d0cd0dc325c3
#15 DONE 0.1s

#16 [stage-1 5/6] COPY --from=BUILD /usr/src/app/target/quarkus-app/app/ /deployments/app/
#16 sha256:7d1622d65df9747dd51ca2d404d4152fcad7fcf869554df1d7de08d3e085b23f
#16 DONE 0.0s

#17 [stage-1 6/6] COPY --from=BUILD /usr/src/app/target/quarkus-app/quarkus/ /deployments/quarkus/
#17 sha256:af9341d62c731c305d87838c5271fa772879966a57094dd69143f61c3bd7ef5b
#17 DONE 0.0s

#18 exporting to image
#18 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
#18 exporting layers
#18 exporting layers 3.5s done
#18 writing image sha256:16b5bec67b72089179c22cf1552f3ebc9d06cf9a04f80da90ac600c1774695bf done
#18 naming to docker.io/library/mqquarkus done
#18 DONE 3.5s
```